### PR TITLE
Added a `run!` macro for useEffect behavior

### DIFF
--- a/examples/iter.rs
+++ b/examples/iter.rs
@@ -11,21 +11,18 @@ fn main() -> std::io::Result<()> {
 pub fn app() -> Rsx {
     let items: State<Vec<i32>> = use_state(vec![1, 2]);
 
-    std::thread::spawn({
-        let items = items.clone();
-        move || {
-            std::thread::sleep(std::time::Duration::from_millis(1000));
+    run! {
+        use items
+        {
+            std::thread::sleep(std::time::Duration::from_millis(300));
             items.get().push(3);
-            std::thread::sleep(std::time::Duration::from_millis(1000));
-            items.get().remove(0);
         }
-    });
+    }
 
     rsx! {
         FlexRow {
             for item in items {
                 static "{item}"
-                static "Idk {item}"
             }
         }
     }

--- a/examples/iter.rs
+++ b/examples/iter.rs
@@ -10,12 +10,12 @@ fn main() -> std::io::Result<()> {
 
 pub fn app() -> Rsx {
     let items: State<Vec<i32>> = use_state(vec![1, 2]);
+    let count = use_state(3);
 
     run! {
-        use items
-        {
-            std::thread::sleep(std::time::Duration::from_millis(300));
-            items.get().push(3);
+        use count ref items {
+            items.get().push(count.get_dl());
+            **count.get() += 1;
         }
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -197,8 +197,8 @@ macro_rules! transform {
 /// ```rust
 /// let count = use_state(0);
 /// run! {
-///     ref count // ref means that it will only reference the count (clone)
 ///     use count // implement count as a dependency, running this again if it updates
+///     ref count // ref means that it will only reference the count (clone)
 ///     {
 ///          // do something with the count
 ///     }


### PR DESCRIPTION
## Example
```rust
let items: State<Vec<i32>> = use_state(vec![1, 2]);
let count = use_state(3);

run! {
    use count ref items {
        items.get().push(count.get_dl());
        **count.get() += 1;
    }
}

rsx! {
    FlexRow {
        for item in items {
            static "{item}"
        }
    }
}
```